### PR TITLE
Technical Documentation: Sphinx autogen

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,7 @@ __pycache__/
 
 # Distribution / packaging
 .Python
-build/
+docs/build/
 develop-eggs/
 dist/
 downloads/

--- a/bmfuncts/config_utils.py
+++ b/bmfuncts/config_utils.py
@@ -167,7 +167,7 @@ def set_user_config(bibliometer_path, year, db_list):
     The parameters set are returned in a tuple as follows:
     - index 1 = the hierarchical dict giving the rawdata full paths (path) for each database;
     - index 2 = the hierarchical dict giving the parsing full paths (path) for each parsing step 
-                and for each database;
+    and for each database;
     - index 3 = the dict giving the name of the parsing file for each parsed item.            
 
     Args:
@@ -234,12 +234,11 @@ def set_org_params(institute, bibliometer_path):
     - index 4 = the list of tuples giving the potential labels (str) of the Institute 
     in the authors affiliations associated with the country (str) that will be used 
     to filter the authors affiliated to the Institute;
-        ex: [("LITEN","France"), ("INES","France")]
+    ex: [("LITEN","France"), ("INES","France")]
     - index 5 = the list of columns names (str) that will be used for each of the potential labels 
     of the Institute filtering the authors affiliated to the Institute;
-    - index 6 = the status (bool) of the impact factors database 
-        - True, if the database specific to the Institute will be used;
-        - False, if a general database will be used;
+    - index 6 = the status (bool) of the impact factors database: True, if the database specific
+    to the Institute will be used; False, if a general database will be used;
     - index 7 = the list of document types (str) for which the impact factors will not be analysed.
 
     Args:

--- a/bmgui/gui_utils.py
+++ b/bmgui/gui_utils.py
@@ -1,4 +1,4 @@
-""" `gui_functions` module contains useful functions for gui management."""
+"""`gui_functions` module contains useful functions for gui management."""
 
 __all__ = ['disable_buttons',
            'enable_buttons',
@@ -160,11 +160,11 @@ def existing_corpuses(bibliometer_path, corpuses_number = None):
     ex:
     If only 2023 files are not present, the returned list of lists is the following:
     [[2018, 2019, 2020, 2021, 2022, 2023],   #Years
-     [True,True,True,True,True,False],       #Wos Rawdata
-     [True,True,True,True,True,False],       #Scopus Rawdata
-     [True,True,True,True,True,False],       #Wos Parsing
-     [True,True,True,True,True,False],       #Scopus Parsing
-     [True,True,True,True,True,False]]       #Concatenation & Deduplication.
+    [True,True,True,True,True,False],       #Wos Rawdata
+    [True,True,True,True,True,False],       #Scopus Rawdata
+    [True,True,True,True,True,False],       #Wos Parsing
+    [True,True,True,True,True,False],       #Scopus Parsing
+    [True,True,True,True,True,False]]       #Concatenation & Deduplication.
 
     Args:
         bibliometer_path (path):  The working folder path.

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,0 +1,20 @@
+# Minimal makefile for Sphinx documentation
+#
+
+# You can set these variables from the command line, and also
+# from the environment for the first two.
+SPHINXOPTS    ?=
+SPHINXBUILD   ?= sphinx-build
+SOURCEDIR     = .
+BUILDDIR      = build
+
+# Put it first so that "make" without argument is like "make help".
+help:
+	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+.PHONY: help Makefile
+
+# Catch-all target: route all unknown targets to Sphinx using the new
+# "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
+%: Makefile
+	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,0 +1,45 @@
+"""
+Technical Documentation: Sphinx configuration file
+"""
+
+# Configuration file for the Sphinx documentation builder.
+#
+# For the full list of built-in configuration values, see the documentation:
+# https://www.sphinx-doc.org/en/master/usage/configuration.html
+
+# -- Project information -----------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
+
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(".."))
+sys.path.insert(0, os.path.abspath("../bmfuncts"))
+sys.path.insert(0, os.path.abspath("../bmgui"))
+
+
+project = 'BiblioMeter'
+copyright = 'Liten, Leti, CEA'
+author = 'Amal CHABLI, François BERTIN, Ludovic DESMEUZES, Baptiste REFALO'
+release = '5.0.0'
+
+# -- General configuration ---------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration
+
+extensions = [
+    'sphinx.ext.autodoc',
+    'sphinx.ext.napoleon',
+    'sphinx.ext.viewcode',
+    'myst_parser',
+]
+source_suffix = [".rst", ".md"]
+
+templates_path = ['_templates']
+exclude_patterns = []
+
+
+# -- Options for HTML output -------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output
+
+html_theme = 'sphinx_rtd_theme'
+html_static_path = ['_static']

--- a/docs/functions/functions.rst
+++ b/docs/functions/functions.rst
@@ -1,0 +1,109 @@
+bmfuncts
+========
+
+Package containing all the modules used on the backend side of the application.
+
+
+bmfuncts.config\_utils
+----------------------
+
+.. automodule:: bmfuncts.config_utils
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+bmfuncts.consolidate\_pub\_list
+-------------------------------
+
+.. automodule:: bmfuncts.consolidate_pub_list
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+bmfuncts.employees\_globals
+---------------------------
+
+.. automodule:: bmfuncts.employees_globals
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+bmfuncts.institute\_globals
+---------------------------
+
+.. automodule:: bmfuncts.institute_globals
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+bmfuncts.merge\_pub\_employees
+------------------------------
+
+.. automodule:: bmfuncts.merge_pub_employees
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+bmfuncts.pub\_analysis
+----------------------
+
+.. automodule:: bmfuncts.pub_analysis
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+bmfuncts.pub\_globals
+---------------------
+
+.. automodule:: bmfuncts.pub_globals
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+bmfuncts.rename\_cols
+---------------------
+
+.. automodule:: bmfuncts.rename_cols
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+bmfuncts.save\_final\_results
+-----------------------------
+
+.. automodule:: bmfuncts.save_final_results
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+bmfuncts.update\_employees
+--------------------------
+
+.. automodule:: bmfuncts.update_employees
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+bmfuncts.update\_impact\_factors
+--------------------------------
+
+.. automodule:: bmfuncts.update_impact_factors
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+bmfuncts.use\_pub\_attributes
+-----------------------------
+
+.. automodule:: bmfuncts.use_pub_attributes
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+bmfuncts.useful\_functs
+-----------------------
+
+.. automodule:: bmfuncts.useful_functs
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/gui/gui.rst
+++ b/docs/gui/gui.rst
@@ -1,0 +1,61 @@
+bmgui
+=====
+
+Package containing the definition of the graphical user interface.
+
+
+bmgui.analyze\_corpus\_page
+---------------------------
+
+.. automodule:: bmgui.analyze_corpus_page
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+bmgui.consolidate\_corpus\_page
+-------------------------------
+
+.. automodule:: bmgui.consolidate_corpus_page
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+bmgui.gui\_globals
+------------------
+
+.. automodule:: bmgui.gui_globals
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+bmgui.gui\_utils
+----------------
+
+.. automodule:: bmgui.gui_utils
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+bmgui.main\_page
+----------------
+
+.. automodule:: bmgui.main_page
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+bmgui.parse\_corpus\_page
+-------------------------
+
+.. automodule:: bmgui.parse_corpus_page
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+bmgui.update\_if\_page
+----------------------
+
+.. automodule:: bmgui.update_if_page
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,0 +1,31 @@
+.. BiblioMeter documentation master file, created by
+   sphinx-quickstart on Fri Sep 27 10:11:55 2024.
+   You can adapt this file completely to your liking, but it should at least
+   contain the root `toctree` directive.
+
+BiblioMeter's Documentation
+===========================
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Introduction
+
+   readme/presentation.md
+
+.. toctree::
+   :maxdepth: 2
+   :caption: BiblioMeter Functions
+
+   functions/functions.rst
+
+.. toctree::
+   :maxdepth: 2
+   :caption: BiblioMeter GUI
+
+   gui/gui.rst
+
+Indices and tables
+==================
+
+* :ref:`genindex`
+* :ref:`modindex`

--- a/docs/make.bat
+++ b/docs/make.bat
@@ -1,0 +1,35 @@
+@ECHO OFF
+
+pushd %~dp0
+
+REM Command file for Sphinx documentation
+
+if "%SPHINXBUILD%" == "" (
+	set SPHINXBUILD=sphinx-build
+)
+set SOURCEDIR=.
+set BUILDDIR=build
+
+%SPHINXBUILD% >NUL 2>NUL
+if errorlevel 9009 (
+	echo.
+	echo.The 'sphinx-build' command was not found. Make sure you have Sphinx
+	echo.installed, then set the SPHINXBUILD environment variable to point
+	echo.to the full path of the 'sphinx-build' executable. Alternatively you
+	echo.may add the Sphinx directory to PATH.
+	echo.
+	echo.If you don't have Sphinx installed, grab it from
+	echo.https://www.sphinx-doc.org/
+	exit /b 1
+)
+
+if "%1" == "" goto help
+
+%SPHINXBUILD% -M %1 %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+goto end
+
+:help
+%SPHINXBUILD% -M help %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+
+:end
+popd

--- a/docs/readme/presentation.md
+++ b/docs/readme/presentation.md
@@ -1,0 +1,90 @@
+# BiblioMeter
+
+## Purpose
+- Outil d’aide à l’analyse de la production scientifique d’un institut
+- Outil utilisable sans prérequis
+  - d’installation du language de développement (lancement par un exécutable
+autoportant)
+  - en connaissance de programmation
+- La production scientifique brute est issue des bases de données
+bibliographiques courantes (WoS, Scopus, HAL... PubMed... )
+- L’outil produit des données nettoyées compatibles avec un
+traitement par les outils de bureautique disponibles de manière
+standard chez les utilisateurs (xlsx, html, png...)
+
+## Interfaces
+
+1. Analyse élémentaire des extractions des bases de données
+- Redistribution des informations extraites de chaque base de données par type
+  - Index des publications, auteurs, affiliations, pays, institutions, références, mots clefs par type,
+catégories de journal...
+- Synthèse de ces informations à partir de toutes les bases de données utilisées
+  - Normalisation de certaines informations pour le retrait des doublons
+- Les informations disponibles ne sont pas toutes exploitées dans l’analyse
+approfondie mais sont prévues de l’être
+  - Éditeur, nature du journal, auteur contact...
+
+2. Consolidation des corpus par les données de l’Institut
+- Identification des attributs des auteurs affiliés à l’Institut
+  - Département, service, labo, statut (CDI, CDD, Postdoctorants, Doctorants...)
+- Gestion des homonymies et des erreurs (interventions manuelles)
+  - Orthographe, métadonnées, collaborateurs externes...
+  - Corrections pérennes indépendament du renouvellement des extractions
+- Gestion de l’attribution des OTPs (interventions manuelles)
+  - Par département
+  - Attributions pérennes indépendament du renouvellement des extractions
+- Consolidation de la liste des publications intégrant toutes les informations traitées
+  - Attributions des IFs disponibles et identification des manques
+
+3. Analyse approfondie des corpus et calcul des indicateurs
+- Analyse de la distribution de la production par type de publication
+  - Journaux, actes de conférence, ouvrages...
+- Analyse de l’évolution temporelle des IFs
+  - Max, min, moyen...
+- Analyse des mots clefs par type
+  - Auteurs, titre, journal...
+- Analyses en cours de mise en place
+  - Fonction des auteurs, Institutions, éditeurs, type d’accès (abonnement, libre,
+hybride)...
+
+4. Interface d’utilisation
+- Fenêtre principale de lancement
+  - Gestion du dossier de travail
+- Fenêtre de travail avec 4 onglets spécialisés
+  - Analyse élémentaire des corpus (6 corpus annuels possibles)
+  - Consolidation annuelle des corpus
+  - Mise à jour des facteurs d’impact (au fur et à mesure de leur disponibilité)
+  - KPIs et graphes (analyse approfondie des corpus et calcul des indicateurs)
+- Fenêtres « messages » en fonction de l’avancement du traitement
+  - Gestion des erreurs prévisibles (ex : fichier attendu indisponible)
+  - Gestion des erreurs non traitées sans arrêt fatal de l’outil
+
+## Input Data
+
+- Les variables globales spécifiques à chaque groupe de fonctions
+  - Actuellement modifiables par intervention dans les modules dédiés du programme
+  - En cours de basculement dans des fichiers « texte » structurés (.yaml)
+- Fichiers annuels d’extraction des bases de données (Scopus, WoS...)
+  spécifiques de l’Institut
+  - Fichiers annuels sur 10 ans des effectifs spécifiques de l’Institut
+  - Fichiers annuels sur 6 ans des facteurs d’impact pour les journaux
+  spécifiques de l’Institut
+
+**La position de ces fichiers est prédéterminée
+dans l’arborescence du dossier de travail**
+
+## Output Data
+
+- Les fichiers issus de l’analyse élémentaire des extractions
+  - Fichiers « texte » structurés (.dat) pour chaque type d’information
+  - 1 fichier « xlsx » pour le contrôle du résultat de la synthèse des extractions
+- Les fichiers issus des étapes de consolidation des corpus
+  - Fichiers « xlsx » pour les interventions manuelles (erreurs d’affiliation, homonymes, OTPs, IFs)
+  - Fichiers « xlsx » des listes consolidées des publications pour une exploitation ultérieure libre
+- Les fichiers issus des étapes d’analyse approfondie
+  - Fichiers « xlsx » et « html » issus de l’analyse annuelle de la production par type de publication
+  - Fichiers « xlsx » et « png » issus de l’analyse annuelle de la production par type de mots clefs
+  - 1 fichier « xlsx » rassemblant les indicateurs de l’ensemble des années disponibles
+
+**La position de ces fichiers est prédéterminée
+dans l’arborescence du dossier de travail**


### PR DESCRIPTION
This update allows to auto-generate the technical documentation (using Sphinx) in a variety of formats: for instance, the generated HTML doc can be deployed and used on GitHub. A PDF generation is also possible, although a bit more complex.