### PR TITLE
Update exe build and name of default working folder

### DIFF
--- a/BiblioMeterBuildExe.bat
+++ b/BiblioMeterBuildExe.bat
@@ -1,5 +1,5 @@
 :: Creation: F. Bertin 2024-05-26
-:: Refactoring: A. Chabli 2024-10-31
+:: Refactoring: A. Chabli 2024-11-13
 
 @echo off 
 Title BiblioMeter.exe making
@@ -23,8 +23,9 @@ echo:
 set "TAB=   "
 
 :: Setting useful directories
-set "working_dir=%TEMP%\BIBLIO_exe"
-set "save_dir=C:\Program"
+set "working_dir=%TEMP%\BiblioMeter_exe"
+:: set "save_dir=C:\Program"
+set "save_dir=%USERPROFILE%\BiblioMeter_exe"
 
 :: Setting the name of the log file to debbug the executable making
 set "LOG=%working_dir%\log.txt"
@@ -165,7 +166,7 @@ for /f "skip=1" %%x in ('wmic os get localdatetime') do if not defined MyDate se
 for /f %%x in ('wmic path win32_localtime get /format:list ^| findstr "="') do set %%x
 set fmonth=00%Month%
 set fday=00%Day%
-set dir_name="%Year%-%fmonth:~-2%-%fday:~-2% BiblioMeter %exe_version%"
+set dir_name="%Year%-%fmonth:~-2%-%fday:~-2% BiblioMeter"
 rename %working_dir%\dist %dir_name%
 if not exist %working_dir%\dist (
     echo The executable directory successfully renamed to %dir_name% >> %LOG%
@@ -187,14 +188,14 @@ echo %working_dir% cleaned successfully >> %LOG%
 echo %TAB%%working_dir% cleaned successfully 
 echo:
 
-:: Renaming the built exe
+:: Renaming the built exe to BiblioMeter-#.#.#
 echo Renaming the built exe
-set "new_file_name=%dir_name%.exe"
-ren %dir_name%\app.exe %new_file_name%
-if exist %dir_name%\%new_file_name% (
-    echo The executable is renamed to %new_file_name% >> %LOG%
+set "exe_file_name=BiblioMeter-%exe_version%.exe"
+ren %dir_name%\app.exe %exe_file_name%
+if exist %dir_name%\%exe_file_name% (
+    echo The executable is renamed to %exe_file_name% >> %LOG%
     echo The executable is located in the directory: %working_dir%\%dir_name% >> %LOG%
-    echo %TAB%The executable is renamed to %new_file_name%    
+    echo %TAB%The executable is renamed to %exe_file_name%    
     echo %TAB%The executable is located in the directory:
     echo %TAB%%TAB%%working_dir%\%dir_name%
 ) else (
@@ -237,12 +238,12 @@ if exist %output_dir% (
     goto RETRY)
 :COPY_FILE
 echo %TAB%Please wait while copying the built exe...
-set "input_file=%working_dir%\%dir_name%\%new_file_name%"
-set "output_file=%output_dir%\%new_file_name%"
+set "input_file=%working_dir%\%dir_name%\%exe_file_name%"
+set "output_file=%output_dir%\%exe_file_name%"
 copy %input_file% %output_file%
 if %ERRORLEVEL% == 0 (
-    echo %new_file_name% file successfully saved in %output_dir% directory >> %LOG%
-    echo %TAB%%new_file_name% file successfully saved in %output_dir% directory
+    echo %exe_file_name% file successfully saved in %output_dir% directory >> %LOG%
+    echo %TAB%%exe_file_name% file successfully saved in %output_dir% directory
     goto FIN
 ) else (
     echo %TAB%Errors encountered during copy of exe file.  Copy canceled with status: %errorlevel%

--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ app.mainloop()
 - 4.0.0 Extension to different institutes
 - 5.0.0 Introduction of progress bars, pylint refactoring of code and Sphynx documentation
 - 5.1.0 Enhanced orphan authors treatment
+- 6.0.0 Enhanced OTPs treatment
 
 # Meta
 	- authors: BiblioAnalysis team

--- a/bmfuncts/__init__.py
+++ b/bmfuncts/__init__.py
@@ -1,6 +1,6 @@
 """ `__init__` module of `bmfuncts` package."""
 
-__version__ = '5.1.0'
+__version__ = '6.0.0'
 __author__  = 'BiblioMeter team'
 __license__ = 'MIT'
 

--- a/bmgui/__init__.py
+++ b/bmgui/__init__.py
@@ -1,7 +1,7 @@
 """ `bmgui` package __init__.
 """
 
-__version__ = '5.1.0'
+__version__ = '6.0.0'
 __author__ = 'BiblioMeter team'
 __license__ = 'MIT'
 

--- a/bmgui/gui_globals.py
+++ b/bmgui/gui_globals.py
@@ -88,7 +88,8 @@ __all__ = ['ADD_SPACE_MM',
            'TEXT_VERSION',
            'TEXT_YEAR_PC',
            'TEXT_YEAR_PI',
-           'GUI_BUTTONS'
+           'GUI_BUTTONS',
+           'VERSION',
            ]
 
 # Standard library imports
@@ -102,7 +103,7 @@ from screeninfo import get_monitors
 # *****************************************
 
 # Setting BiblioMeter version value (internal)
-VERSION = '5.1.0'
+VERSION = '6.0.0'
 
 # Setting the number of corpuses to analyse
 CORPUSES_NUMBER = 6
@@ -182,7 +183,7 @@ FONT_NAME = "Helvetica"
 # **** REFERENCE COORDINATES FOR PAGES ****
 
 # Number of characters reference for editing the entered files-folder path
-REF_ENTRY_NB_CHAR = 100
+REF_ENTRY_NB_CHAR = 110
 
 # Font size references for page label and button
 REF_SUB_TITLE_FONT_SIZE = 15

--- a/bmgui/main_page.py
+++ b/bmgui/main_page.py
@@ -232,7 +232,7 @@ class AppMain(tk.Tk):
 
             # Managing working folder (bmf stands for "BiblioMeter_Files")
             institute_select = args[0]
-            inst_default_bmf = ig.WORKING_FOLDERS_DICT[institute_select]
+            inst_default_bmf = ig.WORKING_FOLDERS_DICT[institute_select] + "-" + gg.VERSION
             _set_bmf_widget_param(institute_select, inst_default_bmf, datatype_select)
 
             # Managing corpus list
@@ -291,13 +291,11 @@ class AppMain(tk.Tk):
 
         # Setting class attributes and methods
         _ = get_monitors() # Mandatory
-        #self.lift()
         self.attributes("-topmost", True)
         self.after_idle(self.attributes,'-topmost', False)
         icon_path = Path(__file__).parent.parent / Path('bmfuncts') / Path(pg.CONFIG_FOLDER)
         icon_path = icon_path / Path('BM-logo.ico')
         self.iconbitmap(icon_path)
-        #self.REP = list()
 
         # Initializing AppMain attributes set after working folder definition
         AppMain.years_list          = []

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ with open(path.join(this_directory, 'requirements.txt'), encoding='utf-8') as f:
 # This setup is suitable for "python setup.py develop".
 
 setup(name='BiblioMeter',
-      version='5.1.0',
+      version='6.0.0',
       description='An application for bibliometry',
       long_description=long_description,
       long_description_content_type='text/markdown',


### PR DESCRIPTION
The batch file for exe building and the "BiblioMeterBuildExeManual-Fr.pdf" files have been updated to set the exe name to "BiblioMeter-#.#.#.exe" where #.#;# is the version number of the BiblioMeter application.
In addition, the default working folder of the selected  Institute is automatically added with this version number. This requires changes in the following modules: bmgui.main.py and bmgui.gui_globals.py.
Also, the version under test (6.0.0) has been put in setup.py, bm_gui.init,py, bmfuncts.init.py and bmgui.gui_globals.py.
Please check this changes before merge into v6.0.0.
Thanks.