### PR TITLE
Add authors full list and publication Hash-id to the saved results

### DIFF
--- a/bmfuncts/add_ifs.py
+++ b/bmfuncts/add_ifs.py
@@ -18,7 +18,6 @@ import pandas as pd
 # Local imports
 import bmfuncts.pub_globals as pg
 from bmfuncts.format_files import format_page
-from bmfuncts.format_files import set_base_keys_list
 from bmfuncts.rename_cols import set_final_col_names
 from bmfuncts.rename_cols import set_if_col_names
 from bmfuncts.useful_functs import concat_dfs
@@ -354,8 +353,8 @@ def _build_missing_issn_and_if_df(if_df, inst_issn_df, cols_tup, empty_kw):
     return missing_if_df, missing_issn_df
 
 
-def _format_and_save_add_if_dfs(institute, org_tup, dfs_tup, out_cols_tup,
-                                empty_kw, out_paths_tup):
+def _format_and_save_add_if_dfs(dfs_tup, out_cols_tup, empty_kw,
+                                out_paths_tup, corpus_year):
     # Setting parameters from args
     corpus_df, year_missing_issn_df, year_missing_if_df = dfs_tup
     out_file_path, missing_issn_path, missing_if_path = out_paths_tup
@@ -366,23 +365,22 @@ def _format_and_save_add_if_dfs(institute, org_tup, dfs_tup, out_cols_tup,
     sorted_year_missing_if_df = _format_missing_df(
         year_missing_if_df, out_cols_tup, empty_kw, add_cols=False)
 
-    # Setting useful parameters for use of 'format_page' function
-    common_df_title = pg.DF_TITLES_LIST[0]
-    format_cols_list = set_base_keys_list(institute, org_tup)
-
     # Formatting and saving 'corpus_df' as openpyxl file at full path 'out_file_path'
-    wb, _ = format_page(corpus_df, common_df_title,
-                        attr_keys_list=format_cols_list)
+    corpus_df_title = pg.DF_TITLES_LIST[0]
+    wb, ws = format_page(corpus_df, corpus_df_title)
+    ws.title = "Publications " +  corpus_year
     wb.save(out_file_path)
 
     # Saving 'year_missing_issn_df' as openpyxl file at full path 'missing_issn_path'
-    wb, _ = format_page(sorted_year_missing_issn_df, common_df_title,
-                        attr_keys_list=format_cols_list)
+    missing_issn_df_title = pg.DF_TITLES_LIST[18]
+    wb, ws = format_page(sorted_year_missing_issn_df, missing_issn_df_title)
+    ws.title = "ISSNs manquants " +  corpus_year
     wb.save(missing_issn_path)
 
     # Saving 'year_missing_if_df' as openpyxl file at full path 'missing_if_path'
-    wb, _ = format_page(sorted_year_missing_if_df, common_df_title,
-                        attr_keys_list=format_cols_list)
+    missing_if_df_title = pg.DF_TITLES_LIST[18]
+    wb, ws = format_page(sorted_year_missing_if_df, missing_if_df_title)
+    ws.title = "IFs manquants " +  corpus_year
     wb.save(missing_if_path)
 
 
@@ -487,10 +485,8 @@ def add_if(institute, org_tup, bibliometer_path, paths_tup, corpus_year):
     values of the most recent year available in the 'if_dict' dict. 
     In these columns, the NaN values of impact-factors are replaced 
     by 'unknown_if_fill_alias'. 
-    The results are saved as openpyxl workbook formatted through the `format_page`
-    function imported from the `bmfuncts.format_files` module after 
-    setting the attrubutes keys list through the `set_base_keys_list` function 
-    imported from the same module.
+    The results are saved as openpyxl workbook formatted through the 
+    `_format_and_save_add_if_dfs` internal function.
 
     Args:
         institute (str): Institute name.
@@ -616,8 +612,8 @@ def add_if(institute, org_tup, bibliometer_path, paths_tup, corpus_year):
     out_paths_tup = (out_file_path, missing_issn_path, missing_if_path)
 
     # Formatting and saving the built dataframes as openpyxl workbooks
-    _format_and_save_add_if_dfs(institute, org_tup, dfs_tup, out_cols_tup,
-                                empty_kw_alias, out_paths_tup)
+    _format_and_save_add_if_dfs(dfs_tup, out_cols_tup, empty_kw_alias,
+                                out_paths_tup, corpus_year)
 
     end_message = f"IFs added for year {corpus_year} in file : \n  '{out_file_path}'"
     return end_message, if_database_complete

--- a/bmfuncts/add_otps.py
+++ b/bmfuncts/add_otps.py
@@ -25,7 +25,6 @@ from bmfuncts.format_files import build_data_val
 from bmfuncts.format_files import format_page
 from bmfuncts.format_files import format_wb_sheet
 from bmfuncts.format_files import get_col_letter
-from bmfuncts.format_files import set_base_keys_list
 from bmfuncts.rename_cols import build_col_conversion_dic
 from bmfuncts.rename_cols import set_otp_col_names
 from bmfuncts.useful_functs import concat_dfs
@@ -166,7 +165,7 @@ def _add_authors_name_list(institute, org_tup, in_df):
     matricule_alias = bm_col_rename_dic[eg.EMPLOYEES_USEFUL_COLS['matricule']]
     full_name_alias = bm_col_rename_dic[pg.COL_NAMES_BONUS['nom prénom'] + institute]
     author_type_alias = bm_col_rename_dic[pg.COL_NAMES_BONUS['author_type']]
-    full_name_list_alias = bm_col_rename_dic[pg.COL_NAMES_BONUS['nom prénom liste'] + institute]
+    full_name_list_alias = bm_col_rename_dic[pg.COL_NAMES_BONUS['nom prénom liste']]
     dept_alias = bm_col_rename_dic[eg.EMPLOYEES_USEFUL_COLS['dpt']]
     serv_alias = bm_col_rename_dic[eg.EMPLOYEES_USEFUL_COLS['serv']]
     lab_alias = bm_col_rename_dic[eg.EMPLOYEES_USEFUL_COLS['lab']]
@@ -242,7 +241,7 @@ def _enhance_homonyms_file(institute, org_tup, in_path):
     return final_solved_homonymies_df
 
 
-def _save_dpt_otp_file(institute, org_tup, dpt, dpt_df, dpt_otp_list,
+def _save_dpt_otp_file(dpt, dpt_df, dpt_otp_list,
                        otp_alias, xl_dpt_path, otp_col_list):
     """Creates an openpyxl file to allow the user to set the OTP attribute   
     of the publications for the Institute department labelled 'dpt'.
@@ -266,8 +265,6 @@ def _save_dpt_otp_file(institute, org_tup, dpt, dpt_df, dpt_otp_list,
     'xl_dpt_path'.
 
     Arg:
-        institute (str): Institute name.
-        org_tup (tup): Contains Institute parameters.
         dpt (str): Institute department.
         dpt_df (dataframe): The publications-list dataframe of the 'dpt' department.
         dpt_otp_list (list): List of Institute departments (str).
@@ -289,9 +286,8 @@ def _save_dpt_otp_file(institute, org_tup, dpt, dpt_df, dpt_otp_list,
     dpt_df = dpt_df.reindex(columns=otp_col_list)
 
     # Formatting 'dpt_df' as openpyxl workbook
-    attr_keys_list = set_base_keys_list(institute, org_tup)
     dpt_df_title = pg.DF_TITLES_LIST[2]
-    wb, ws = format_page(dpt_df, dpt_df_title, attr_keys_list=attr_keys_list)
+    wb, ws = format_page(dpt_df, dpt_df_title)
     ws.title = pg.OTP_SHEET_NAME_BASE + " " +  dpt
 
     # Activating the validation data list in all cells of the OTPs column
@@ -376,12 +372,12 @@ def _add_dept_otp(institute, org_tup, in_path, out_path, out_file_base):
         xl_dpt_path = out_path / Path(otp_file_name_dpt)
 
         # Adding a column with validation list for OTPs and saving the file
-        _save_dpt_otp_file(institute, org_tup, dpt, dpt_df, dpt_otp_list,
+        _save_dpt_otp_file(dpt, dpt_df, dpt_otp_list,
                            otp_alias, xl_dpt_path, otp_col_list)
 
 
-def _save_dpt_lab_otp_file(institute, org_tup, dpt_df, dpt_otp_dict,
-                           xl_dpt_path, otp_col_dic, otp_lab_name_col, dpt):
+def _save_dpt_lab_otp_file(institute, dpt_df, dpt_otp_dict, xl_dpt_path,
+                           otp_col_dic, otp_lab_name_col, dpt):
     """Creates an openpyxl file to allow the user to set the OTP attribute   
     of the publications for each laboratory of a department of the Institute. 
 
@@ -405,7 +401,6 @@ def _save_dpt_lab_otp_file(institute, org_tup, dpt_df, dpt_otp_dict,
 
     Arg:
         institute (str): Institute name.
-        org_tup (tup): Contains Institute parameters.
         dpt_df (dataframe): The publications-list dataframe of a department of \
         the Institute.
         dpt_otp_dict (dict): Dict keyed by lab-names and valued by lab-OTPs lists.
@@ -421,9 +416,6 @@ def _save_dpt_lab_otp_file(institute, org_tup, dpt_df, dpt_otp_dict,
 
     # Setting useful aliases
     otp_alias = otp_col_dic['otp_list']
-
-    # Setting col attributes keys
-    attr_keys_list = set_base_keys_list(institute, org_tup)
 
     # Setting useful-columns list of OTP df
     otp_col_list = list(otp_col_dic.values())
@@ -450,8 +442,7 @@ def _save_dpt_lab_otp_file(institute, org_tup, dpt_df, dpt_otp_dict,
             sheet_name = otp_lab
             otp_lab_df_title = pg.DF_TITLES_LIST[2]
             wb = format_wb_sheet(sheet_name, otp_lab_df,
-                                 otp_lab_df_title, wb, first,
-                                 attr_keys_list=attr_keys_list)
+                                 otp_lab_df_title, wb, first)
             ws = wb.active
 
             # Getting the column letter for the OTPs column
@@ -468,7 +459,7 @@ def _save_dpt_lab_otp_file(institute, org_tup, dpt_df, dpt_otp_dict,
 
         # Formatting 'dpt_df' as openpyxl workbook
         dpt_df_title = pg.DF_TITLES_LIST[2]
-        wb, ws = format_page(dpt_df, dpt_df_title, attr_keys_list=attr_keys_list)
+        wb, ws = format_page(dpt_df, dpt_df_title)
         dpt_label = dpt
         if dpt=="DIR":
             dpt_label = "(" + institute.upper() + ")"
@@ -584,6 +575,7 @@ def _build_otp_dept_df(institute, org_tup, otp_col_dic,
             otp_dpt_df = concat_dfs([otp_dpt_df, lab_df])
     return otp_dpt_df
 
+
 def _set_full_pub_df(init_pub_df, cols_list, dpt_list):
     """Adds the publications data of one row per publication ID 
     with 1 or 0 assigned to each department column depending
@@ -680,8 +672,8 @@ def _add_lab_otp(institute, org_tup, in_path, out_path, out_file_base, lab_otps_
         xl_dpt_path = out_path / Path(otp_file_name_dpt)
 
        # Adding a column with validation list for OTPs and saving the file
-        _save_dpt_lab_otp_file(institute, org_tup, otp_dpt_df, dpt_otp_dict,
-                               xl_dpt_path, otp_col_dic, otp_lab_name_col, dpt)
+        _save_dpt_lab_otp_file(institute, otp_dpt_df, dpt_otp_dict, xl_dpt_path,
+                               otp_col_dic, otp_lab_name_col, dpt)
 
 
 def add_otp(institute, org_tup, bibliometer_path, in_path, out_path, out_file_base):

--- a/bmfuncts/authors_analysis.py
+++ b/bmfuncts/authors_analysis.py
@@ -338,7 +338,7 @@ def authors_analysis(institute, org_tup, bibliometer_path, datatype,
     author_employee_xlsx_file_path = Path(auth_analysis_folder_path) / Path(year_authors_file + ".xlsx")
     auth_df_title = pg.DF_TITLES_LIST[4]
     wb, ws = format_page(author_employee_df, auth_df_title)
-    ws.title = 'Auteurs' + corpus_year
+    ws.title = 'Auteurs ' + corpus_year
     wb.save(author_employee_xlsx_file_path)
     if progress_callback:
         progress_callback(70)
@@ -347,7 +347,7 @@ def authors_analysis(institute, org_tup, bibliometer_path, datatype,
     author_stat_xlsx_file_path = Path(auth_analysis_folder_path) / Path(year_authors_stat_file + ".xlsx")
     auth_stat_df_title = pg.DF_TITLES_LIST[5]
     wb, ws = format_page(pub_nb_per_author_df, auth_stat_df_title)
-    ws.title = 'Auteurs' + corpus_year
+    ws.title = 'Stat auteurs ' + corpus_year
     wb.save(author_stat_xlsx_file_path)
     if progress_callback:
         progress_callback(80)

--- a/bmfuncts/build_pub_authors.py
+++ b/bmfuncts/build_pub_authors.py
@@ -551,16 +551,16 @@ def _get_input_data(institute, org_tup, bibliometer_path, datatype, corpus_year)
 
 
 def _recasting_authors_df(authors_df, bm_cols_list):
-    """Recasts the data with with one row per Institute author 
-    for each publication by format of authors full names and their 
-    redistribution into last names and firsname initials.
+    """Recasts the data with one row per Institute author 
+    for each publication by formatting the authors full names and their 
+    redistribution into last names and firsnames initials.
 
     Args:
         authors_df (dataframe): Data of publication IDs list \
-        with one row per author resulting from parsing step. 
-        bm_cols_list (list): Useful column names specific to 'BiblioMeter'.
+        with one row per author resulting from the parsing step. 
+        bm_cols_list (list): Useful column names.
     Returns:
-        (dataframe): The recasted data.
+        (dataframe): The recast data.
     """
     # Setting useful alias
     bp_co_auth_alias = bp.COL_NAMES['authors'][2]
@@ -587,7 +587,7 @@ def _recasting_authors_df(authors_df, bm_cols_list):
     # Recasting tuples (NAME, INITIALS) into a single string 'NAME INITIALS'
     col_in = bm_fullname_alias # Last_name + firstname initials
     authors_df[col_in] = authors_df[col_in].apply(lambda x: ' '.join(x))  # pylint: disable=unnecessary-lambda
-    print("    Author name recasted to last name and first-name initials")
+    print("    Author name recast to last name and first-name initials")
     return authors_df
 
 
@@ -595,8 +595,8 @@ def _build_authors_full_list(authors_df, cols_list):
     """Builds the data of authors full-list per publications.
 
     Args:
-        inst_merged_df (dataframe): Data of publications list \
-        with one row per author.  
+        authors_df (dataframe): Data of publication IDs list \
+        with one row per author resulting from the parsing step. 
         cols_list (list): Useful column names.
     Returns:
         (dataframe): The built data.
@@ -620,7 +620,7 @@ def _build_authors_full_list(authors_df, cols_list):
 
 
 def _reorder_cols(inst_merged_df, reorder_cols_list):
-    """Reorders the columns the data with one row per Institute's author 
+    """Reorders the columns of the data with one row per Institute's author 
     for each publication.
 
     The columns of full name, last name and first-name initials are set 
@@ -630,11 +630,11 @@ def _reorder_cols(inst_merged_df, reorder_cols_list):
     imported from `bmfuncts.useful_functs` module.
 
     Args:
-        authors_df (dataframe): Data of publication IDs list \
+        inst_merged_df (dataframe): Data of publication IDs list \
         with one row per author where authors full name has been \
-        formatted and split into last name and first name initials \
+        formatted and split into last name and firstname initials \
         and the misspelled names have been corrected. 
-        cols_list (list): The names of the columns to be reordered.
+        reorder_cols_list (list): The names of the columns to be reordered.
     Returns:
         (dataframe): The data with reordered columns.
     """
@@ -655,13 +655,13 @@ def build_institute_pubs_authors(institute, org_tup, bibliometer_path, datatype,
     """Builds the publications list dataframe with one row per Institute author 
     for each publication from the results of the corpus parsing.
 
-    This done truoght the following steps:
+    This is done through the following steps:
     
     1. The parsing results are got through the `_get_input_data` internal function.
-    2. The authors data resulting from the parsing step are recasted to split \
-    authors full name into last name and first name initials through \
+    2. The authors data resulting from the parsing step are recast to split \
+    authors full name into last name and firstname initials through \
     the `_recasting_inst_merged_df` internal function.
-    3. The misspelling of authors name in the recasted authors data are corrrected \
+    3. The misspelling of authors name in the recast authors data are corrrected \
     through the `_check_names_spelling` internal function. 
     4. The data of full list of authors per publications are built through the \
     `_build_authors_full_list` internal function.

--- a/bmfuncts/consolidate_pub_list.py
+++ b/bmfuncts/consolidate_pub_list.py
@@ -244,8 +244,6 @@ def concatenate_pub_lists(bibliometer_path, years_list):
     imported from `bmfuncts.format_files` module.
 
     Args:
-        institute (str): Institute name.
-        org_tup (tup): Contains Institute parameters.
         bibliometer_path (path): Full path to working folder.
         years_list (list): List of 4 digits years of the available \
         publications lists.

--- a/bmfuncts/coupling_analysis.py
+++ b/bmfuncts/coupling_analysis.py
@@ -351,9 +351,9 @@ def coupling_analysis(institute, org_tup, bibliometer_path,
         # Saving coupling analysis as final result
         status_values = len(pg.RESULTS_TO_SAVE) * [False]
         results_to_save_dict = dict(zip(pg.RESULTS_TO_SAVE, status_values))
-        results_to_save_dict["countries"] = True
-        results_to_save_dict["continents"] = True
-        results_to_save_dict["institutions"] = True
+        save_keys_list = ["countries", "continents", "institutions"]
+        for key in save_keys_list:
+            results_to_save_dict[key] = True
         if_analysis_name = None
         _ = save_final_results(institute, org_tup, bibliometer_path, datatype, year,
                                if_analysis_name, results_to_save_dict, verbose=False)

--- a/bmfuncts/create_hash_id.py
+++ b/bmfuncts/create_hash_id.py
@@ -17,6 +17,7 @@ import BiblioParsing as bp
 import bmfuncts.pub_globals as pg
 from bmfuncts.rename_cols import build_col_conversion_dic
 from bmfuncts.useful_functs import concat_dfs
+from bmfuncts.useful_functs import reorder_df
 
 
 def _my_hash(text:str):
@@ -75,6 +76,22 @@ def _clean_hash_id_df(dfs_tup, cols_tup):
                     new_orphan_df = new_orphan_df[new_orphan_df[pub_id_col]!=pub_id_to_drop]
             add_hash_id_dg = hash_id_dg[hash_id_dg[pub_id_col]==pub_id_to_keep].copy()
         new_hash_id_df = concat_dfs([new_hash_id_df, add_hash_id_dg])
+
+    # Adding column of Hash-IDs and reordering columns in new_submit_df
+    new_submit_df = new_submit_df.merge(new_hash_id_df,
+                                        how="inner",
+                                        on=pub_id_col)
+    col_dict = {hash_id_col: 0}
+    new_submit_df = reorder_df(new_submit_df, col_dict)
+
+    # Adding column of Hash-IDs and reordering columns in new_orphan_df
+    new_orphan_df = new_orphan_df.merge(new_hash_id_df,
+                                        how="inner",
+                                        on=pub_id_col)
+    col_dict = {hash_id_col: 0,
+                pub_id_col : 1}
+    new_orphan_df = reorder_df(new_orphan_df, col_dict)
+
     return new_submit_df, new_orphan_df, new_hash_id_df
 
 

--- a/bmfuncts/format_files.py
+++ b/bmfuncts/format_files.py
@@ -15,7 +15,6 @@ __all__ = ['align_cell',
            'format_wb_sheet',
            'get_col_letter',
            'save_formatted_df_to_xlsx',
-           'set_base_keys_list',
            'set_col_width',
            'set_df_attributes',
           ]
@@ -24,7 +23,6 @@ __all__ = ['align_cell',
 from pathlib import Path
 
 # 3rd party imports
-import BiblioParsing as bp
 from openpyxl import Workbook as openpyxl_Workbook
 from openpyxl.styles import Font as openpyxl_Font
 from openpyxl.styles import PatternFill as openpyxl_PatternFill
@@ -39,9 +37,7 @@ from openpyxl.worksheet.datavalidation import DataValidation \
     as openpyxl_DataValidation
 
 # local imports
-import bmfuncts.employees_globals as eg
 import bmfuncts.pub_globals as pg
-from bmfuncts.rename_cols import build_col_conversion_dic
 
 
 def get_col_letter(df, col, xl_idx_base):
@@ -190,21 +186,14 @@ def set_col_width(ws, columns_list, col_attr, col_idx_init, xl_idx_base):
     return ws
 
 
-def _set_base_attributes(df_cols_list, final_cols_list):
-    """Sets the dict for setting the final column attributes 
+def _set_base_attributes(cols_list):
+    """Sets the dict for setting the default attributes of columns 
     in terms of width and alignment to be used for formating 
     dataframes before openpyxl save.
 
-    The final column names are got through the 
-    `build_col_conversion_dic` internal function.
-
     Args:
-        df_cols_list (list): List of columns names (str) for \
+        cols_list (list): List of columns names (str) for \
         which attributes are to be defined.
-        final_cols_list (list): The list of columns names (str) \
-        that will be used as keys for building the dict \
-        valued by the attributes lists of each column composed \
-        by [horizontal alignment (str), width (int)].
     Returns:
         (tup): (The columns attributes as dict keyed by column names (str) \
         and valued by the attributes lists of each column composed \
@@ -212,24 +201,153 @@ def _set_base_attributes(df_cols_list, final_cols_list):
         The rows attributes as dict keyed by "first_row" and "other_rows" \
         and valued by rows height (int), Num of first column to be formatted (int)).
     """
-    init_attr_list = [[20, "center"], [40, "left"], [15, "center"],
-                      [15, "center"], [20, "center"], [20, "center"],
-                      [40, "left"], [20, "center"], [15, "center"],
-                      [15, "center"], [20, "left"], [15, "center"],
-                      [15, "center"], [40, "left"], [20, "center"],
-                      [15, "center"], [15, "center"], [15, "center"],
-                      [15, "center"], [55, 'left'], [20, "center"],
-                      [85, "center"]]
-    add_attr_nb = len(final_cols_list) - len(init_attr_list)
-    add_attr_list = [[10, "center"]]*add_attr_nb
-    final_attr_list = init_attr_list + add_attr_list
-    col_attr_dict = dict(zip(final_cols_list, final_attr_list))
-    for col in df_cols_list:
-        if col not in final_cols_list:
-            col_attr_dict[col] = [15, "center"]
+    col_attr_dict = {}
+    for col in cols_list:
+        col_attr_dict[col] = [15, "center"]
+    row_heights_dict = {'first_row': 50,
+                        'other_rows': 15}
+    col_idx_init = 0
+    return col_attr_dict, row_heights_dict, col_idx_init
+
+
+def _set_if_issn_attributes(cols_list):
+    """Sets the widths and horizontal alignement of each columns 
+    and the heights of the first row and other rows to be used 
+    for formatting the missing IFs or ISSNs data to be saved.
+
+    Args:
+        cols_list (list): The columns names (str) of the data.
+    Returns:
+        (tup): (The dict keyed by columns names (str) and valued (list) \
+        by the width (int) and the horizontal alignement (str), 
+        The dict keyed by given row types (str) and valued by row heights (int), 
+        The value (int) for initializing columns index).
+    """
+    sub_attr_list = [[15, "center"], [40, "left"]]
+    cols_nb = len(cols_list)
+    set_attr_nb = len(sub_attr_list)
+    add_attr_nb = cols_nb - set_attr_nb
+    attr_list = sub_attr_list \
+              + [[15, "center"]] * add_attr_nb
+    col_attr_dict = dict(zip(cols_list, attr_list))
+
+    # Setting row-heights dict
     row_heights_dict = {'first_row':50,
                         'other_rows':15}
-    col_idx_init = 1
+
+    # Setting value to initialize columns index
+    col_idx_init = 0
+    return col_attr_dict, row_heights_dict, col_idx_init
+
+
+def _set_invalid_list_attributes(cols_list):
+    """Sets the widths and horizontal alignement of each columns 
+    and the heights of the first row and other rows to be used 
+    for formatting the invalid publications list data to be saved.
+
+    Args:
+        cols_list (list): The columns names (str) of the data.
+    Returns:
+        (tup): (The dict keyed by columns names (str) and valued (list) \
+        by the width (int) and the horizontal alignement (str), 
+        The dict keyed by given row types (str) and valued by row heights (int), 
+        The value (int) for initializing columns index).
+    """
+    sub_attr_list = [[15, "center"], [10, "center"]] \
+                  + [[15, "center"]] * 2 \
+                  + [[20, "center"]] \
+                  + [[40, "left"]] * 4 \
+                  + [[20, "center"], [20, "left"],
+                     [55, 'left'], [15, "center"]]
+    cols_nb = len(cols_list)
+    set_attr_nb = len(sub_attr_list)
+    dept_nb = cols_nb - set_attr_nb - 1
+    attr_list = sub_attr_list \
+              + [[10, "center"]] * dept_nb \
+              + [[15, "center"]] * 1
+    col_attr_dict = dict(zip(cols_list, attr_list))
+
+    # Setting row-heights dict
+    row_heights_dict = {'first_row':50,
+                        'other_rows':15}
+
+    # Setting value to initialize columns index
+    col_idx_init = 0
+    return col_attr_dict, row_heights_dict, col_idx_init
+
+
+def _set_pub_list_attributes(cols_list):
+    """Sets the widths and horizontal alignement of each columns 
+    and the heights of the first row and other rows to be used 
+    for formatting the publications list data to be saved.
+
+    Args:
+        cols_list (list): The columns names (str) of the data.
+    Returns:
+        (tup): (The dict keyed by columns names (str) and valued (list) \
+        by the width (int) and the horizontal alignement (str), 
+        The dict keyed by given row types (str) and valued by row heights (int), 
+        The value (int) for initializing columns index).
+    """
+    sub_attr_list = [[15, "center"], [10, "center"]] \
+                  + [[15, "center"]] * 2 \
+                  + [[20, "center"]] \
+                  + [[40, "left"]] * 4 \
+                  + [[20, "center"], [20, "left"],
+                     [55, 'left'], [15, "center"]]
+    cols_nb = len(cols_list)
+    set_attr_nb = len(sub_attr_list)
+    dept_nb = cols_nb - set_attr_nb - 3
+    attr_list = sub_attr_list \
+              + [[10, "center"]] * dept_nb \
+              + [[15, "center"]] * 3
+    col_attr_dict = dict(zip(cols_list, attr_list))
+
+    # Setting row-heights dict
+    row_heights_dict = {'first_row':50,
+                        'other_rows':15}
+
+    # Setting value to initialize columns index
+    col_idx_init = 0
+    return col_attr_dict, row_heights_dict, col_idx_init
+
+
+def _set_def_otp_attributes(cols_list):
+    """Sets the widths and horizontal alignement of each columns 
+    and the heights of the first row and other rows to be used 
+    for formatting the data to be saved for setting OTP per 
+    publication by the user.
+
+    Args:
+        cols_list (list): The columns names (str) of the data.
+    Returns:
+        (tup): (The dict keyed by columns names (str) and valued (list) \
+        by the width (int) and the horizontal alignement (str), 
+        The dict keyed by given row types (str) and valued by row heights (int), 
+        The value (int) for initializing columns index).
+    """
+    sub_attr_list = [[15, "center"], [10, "center"]] \
+                  + [[15, "center"]] * 2 \
+                  + [[20, "center"]] \
+                  + [[40, "left"]] * 4 \
+                  + [[20, "center"], [20, "left"], [55, 'left']] \
+                  + [[15, "center"]] * 3 \
+                  + [[25, "center"]] \
+                  + [[15, "center"]] * 3
+    cols_nb = len(cols_list)
+    set_attr_nb = len(sub_attr_list)
+    dept_nb = cols_nb - set_attr_nb - 1
+    attr_list = sub_attr_list \
+              + [[10, "center"]] * dept_nb \
+              + [[85, "center"]]
+    col_attr_dict = dict(zip(cols_list, attr_list))
+
+    # Setting row-heights dict
+    row_heights_dict = {'first_row':50,
+                        'other_rows':15}
+
+    # Setting value to initialize columns index
+    col_idx_init = 0
     return col_attr_dict, row_heights_dict, col_idx_init
 
 
@@ -698,17 +816,13 @@ def _set_doctype_stat_attributes(cols_list):
     return col_attr_dict, row_heights_dict, col_idx_init
 
 
-def set_df_attributes(df_title, df_cols_list, keys_list):
+def set_df_attributes(df_title, df_cols_list):
     """Sets the attributes for formating a given data type as openpyxl object.
 
     Args:
         df_title (str): Name of the data type to be formatted.
         df_cols_list (list): List of columns names (str) for \
         which attributes are to be defined.
-        keys_list (list): The list of columns names (str) \
-        that will be used as keys for building the dict \
-        valued by the attributes lists of each column composed \
-        by [horizontal alignment (str), width (int)].
     Returns:
         (tup): (The columns attributes as dict keyed by column names (str) \
         and valued by the attributes lists of each column composed \
@@ -717,6 +831,8 @@ def set_df_attributes(df_title, df_cols_list, keys_list):
         and valued by rows height (int), Num of first column to be formatted (int)).
     """
     # Setting useful aliases
+    pub_list_alias = pg.DF_TITLES_LIST[0]
+    def_otp_alias = pg.DF_TITLES_LIST[2]
     if_db_alias = pg.DF_TITLES_LIST[3]
     auth_alias = pg.DF_TITLES_LIST[4]
     auth_stat_alias = pg.DF_TITLES_LIST[5]
@@ -731,10 +847,22 @@ def set_df_attributes(df_title, df_cols_list, keys_list):
     pub_country_inst_alias = pg.DF_TITLES_LIST[14]
     country_inst_pub_alias = pg.DF_TITLES_LIST[15]
     raw_inst_alias = pg.DF_TITLES_LIST[16]
+    invalids_alias = pg.DF_TITLES_LIST[17]
+    missing_if_issn_alias = pg.DF_TITLES_LIST[18]
 
-    attr_tup = _set_base_attributes(df_cols_list, keys_list)
+    if df_title==pub_list_alias:
+        attr_tup = _set_pub_list_attributes(df_cols_list)
 
-    if df_title==if_db_alias:
+    elif df_title==invalids_alias:
+        attr_tup = _set_invalid_list_attributes(df_cols_list)
+
+    elif df_title==missing_if_issn_alias:
+        attr_tup = _set_if_issn_attributes(df_cols_list)
+
+    elif df_title==def_otp_alias:
+        attr_tup = _set_def_otp_attributes(df_cols_list)
+
+    elif df_title==if_db_alias:
         attr_tup = _set_if_db_attributes(df_cols_list)
 
     elif df_title==auth_alias:
@@ -775,63 +903,14 @@ def set_df_attributes(df_title, df_cols_list, keys_list):
 
     elif df_title==raw_inst_alias:
         attr_tup = _set_raw_inst_attributes(df_cols_list)
+
+    else:
+        attr_tup = _set_base_attributes(df_cols_list)
     return attr_tup
 
 
-def set_base_keys_list(institute, org_tup):
-    """Sets the final list of column names of publications list.
-
-    The final column names are got through the 
-    `build_col_conversion_dic` internal function.
-
-    Args:
-        institute (str): The Institute name.
-        org_tup (tup): The tuple of the organization structure \
-        of the Institute.
-    Returns:
-        (list): The list of final column names (str).
-    """
-    # Setting institute parameters
-    col_names_dpt = org_tup[0]
-
-    #  Setting col rename dict
-    col_rename_tup = build_col_conversion_dic(institute, org_tup)
-    all_col_rename_dict = col_rename_tup[2]
-
-    # Building initial col-names list
-    init_col_list = [bp.COL_NAMES['pub_id'],
-                     pg.COL_NAMES_BONUS['nom prénom liste'] + institute ,
-                     bp.COL_NAMES['authors'][1],
-                     eg.EMPLOYEES_USEFUL_COLS['matricule'],
-                     eg.EMPLOYEES_USEFUL_COLS['name'],
-                     eg.EMPLOYEES_USEFUL_COLS['first_name'],
-                     bp.COL_NAMES['articles'][9],
-                     bp.COL_NAMES['articles'][1],
-                     pg.COL_NAMES_BONUS['IF en cours'],
-                     pg.COL_NAMES_BONUS['IF année publi'],
-                     bp.COL_NAMES['articles'][6],
-                     bp.COL_NAMES['articles'][10],
-                     bp.COL_NAMES['articles'][2],
-                     bp.COL_NAMES['articles'][3],
-                     bp.COL_NAMES['articles'][7],
-                     pg.COL_NAMES_BONUS['corpus_year'],
-                     eg.EMPLOYEES_USEFUL_COLS['dpt'],
-                     eg.EMPLOYEES_USEFUL_COLS['serv'],
-                     eg.EMPLOYEES_USEFUL_COLS['lab'],
-                     pg.COL_NAMES_BONUS['liste biblio'],
-                     pg.COL_NAMES_BONUS['homonym'],
-                     pg.COL_NAMES_BONUS['list OTP'],
-                    ]
-    for _,dpt_col_name in col_names_dpt.items():
-        init_col_list.append(col_names_dpt[dpt_col_name])
-
-    # Renaming col names from initial col-names list
-    final_col_list = [all_col_rename_dict[col] for col in list(init_col_list)]
-    return final_col_list
-
-
-def format_page(df, df_title, attr_keys_list=None, wb=None,
-                header=True, cell_colors=None, idx_wrap=None):
+def format_page(df, df_title, wb=None, header=True,
+                cell_colors=None, idx_wrap=None):
     """Formats a worksheet of an openpyxl workbook using 
     columns attributes got through the `set_df_attributes`  
     internal function.
@@ -845,10 +924,6 @@ def format_page(df, df_title, attr_keys_list=None, wb=None,
         df_title (str): Name of data to be formatted for setting \
         columns attributes, to be specified using the 'DF_TITLES_LIST' \
         global defined in `bmfuncts.pub_globals` module.
-        attr_keys_list (list): The list of columns names (str) \
-        that will be used as keys for building the dict \
-        valued by the attributes lists of each column composed \
-        by [horizontal alignment (str), width (int)] (default = None).
         wb (openpyxl workbook): Worbook of the worksheet \
         to be formatted (default = None).
         header (bool): Value of the 'header' arg of the \
@@ -871,9 +946,7 @@ def format_page(df, df_title, attr_keys_list=None, wb=None,
 
     # Setting useful df attributes
     df_cols_list = df.columns
-    if not attr_keys_list:
-        attr_keys_list = df_cols_list
-    attrib_tup = set_df_attributes(df_title, df_cols_list, attr_keys_list)
+    attrib_tup = set_df_attributes(df_title, df_cols_list)
     col_attr_dict, row_heights_dict, col_idx_init = attrib_tup
 
     # Initialize wb as a openpyxl workbook and ws its active worksheet
@@ -910,8 +983,7 @@ def format_page(df, df_title, attr_keys_list=None, wb=None,
     return wb, ws
 
 
-def format_wb_sheet(sheet_name, df, df_title, wb, first,
-                    attr_keys_list=None, idx_wrap=None):
+def format_wb_sheet(sheet_name, df, df_title, wb, first, idx_wrap=None):
     """Formats impact-factors (IFs) sheet in the 'wb' openpyxl workbook 
     as first sheet of the workbook if first is True.
 
@@ -926,24 +998,18 @@ def format_wb_sheet(sheet_name, df, df_title, wb, first,
         global defined in `bmfuncts.pub_globals` module.
         wb (openpyxl workbook): Workbook to be updated with the 'sheet_name' sheet.
         first (bool): True if the sheet to add is the first of the workbook.
-        attr_keys_list (list): The optional list of columns names (str) \
-        that will be used as keys for building the dict \
-        valued by the attributes lists of each column composed \
-        by [horizontal alignment (str), width (int)] (default = None).
         idx_wrap (int): The optional maximum index of the rows \
         for which text is wraped in the last column.
     Returns:
         (openpyxl workbook): The updated workbook with the 'sheet_name' sheet.
     """
     if first:
-        wb, ws = format_page(df, df_title, attr_keys_list=attr_keys_list,
-                             wb=wb, idx_wrap=idx_wrap)
+        wb, ws = format_page(df, df_title, wb=wb, idx_wrap=idx_wrap)
         ws.title = sheet_name
     else:
         wb.create_sheet(sheet_name)
         wb.active = wb[sheet_name]
-        wb, ws = format_page(df, df_title, attr_keys_list=attr_keys_list,
-                             wb=wb, idx_wrap=idx_wrap)
+        wb, ws = format_page(df, df_title, wb=wb, idx_wrap=idx_wrap)
     return wb
 
 

--- a/bmfuncts/format_files.py
+++ b/bmfuncts/format_files.py
@@ -211,7 +211,7 @@ def _set_base_attributes(cols_list):
 
 
 def _set_if_issn_attributes(cols_list):
-    """Sets the widths and horizontal alignement of each columns 
+    """Sets the widths and horizontal alignement of each column 
     and the heights of the first row and other rows to be used 
     for formatting the missing IFs or ISSNs data to be saved.
 
@@ -241,7 +241,7 @@ def _set_if_issn_attributes(cols_list):
 
 
 def _set_invalid_list_attributes(cols_list):
-    """Sets the widths and horizontal alignement of each columns 
+    """Sets the widths and horizontal alignement of each column 
     and the heights of the first row and other rows to be used 
     for formatting the invalid publications list data to be saved.
 
@@ -277,7 +277,7 @@ def _set_invalid_list_attributes(cols_list):
 
 
 def _set_pub_list_attributes(cols_list):
-    """Sets the widths and horizontal alignement of each columns 
+    """Sets the widths and horizontal alignement of each column 
     and the heights of the first row and other rows to be used 
     for formatting the publications list data to be saved.
 
@@ -313,7 +313,7 @@ def _set_pub_list_attributes(cols_list):
 
 
 def _set_def_otp_attributes(cols_list):
-    """Sets the widths and horizontal alignement of each columns 
+    """Sets the widths and horizontal alignement of each column 
     and the heights of the first row and other rows to be used 
     for formatting the data to be saved for setting OTP per 
     publication by the user.
@@ -352,7 +352,7 @@ def _set_def_otp_attributes(cols_list):
 
 
 def _set_auth_attributes(cols_list):
-    """Sets the widths and horizontal alignement of each columns 
+    """Sets the widths and horizontal alignement of each column 
     and the heights of the first row and other rows to be used 
     for formatting the authors data to be saved.
 
@@ -380,7 +380,7 @@ def _set_auth_attributes(cols_list):
 
 
 def _set_auth_stat_attributes(cols_list):
-    """Sets the widths and horizontal alignement of each columns 
+    """Sets the widths and horizontal alignement of each column 
     and the heights of the first row and other rows to be used 
     for formatting the statistics data to be saved for authors 
     scientific production.
@@ -408,7 +408,7 @@ def _set_auth_stat_attributes(cols_list):
 
 
 def _set_attr_dict(cols_list, widths_list, last_cols_nb=1):
-    """ Sets the width and horizontal alignement of each columns 
+    """ Sets the width and horizontal alignement of each column 
     to be used for formatting the data to be saved.
 
     The specified widths are at least the following:
@@ -448,7 +448,7 @@ def _set_attr_dict(cols_list, widths_list, last_cols_nb=1):
     if spec_widths_nb==2:
         last_col_align = "center"
 
-    # Setting width and alignement of each columns as dict
+    # Setting width and alignement of each column as dict
     other_cols_width = widths_list[1]
     last_cols_width = widths_list[-1]
     attr_list = [[first_col_width, first_col_align]] \
@@ -459,12 +459,12 @@ def _set_attr_dict(cols_list, widths_list, last_cols_nb=1):
 
 
 def _set_if_db_attributes(cols_list):
-    """Sets the widths and horizontal alignement of each columns 
+    """Sets the widths and horizontal alignement of each column 
     and the heights of the first row and other rows to be used 
     for formatting the impact-factors (IFs) data to be saved 
     for the update of the IFs database.
 
-    The widths and horizontal alignement of each columns are 
+    The widths and horizontal alignement of each column are 
     set through `_set_attr_dict` internal function.
 
     Args:
@@ -490,12 +490,12 @@ def _set_if_db_attributes(cols_list):
 
 
 def _set_kpi_attributes(cols_list):
-    """Sets the widths and horizontal alignement of each columns 
+    """Sets the widths and horizontal alignement of each column 
     and the heights of the first row and other rows to be used 
     for formatting the key performance indicators (KPIs) data to be saved 
     for the update of the KPIs database.
 
-    The widths and horizontal alignement of each columns are 
+    The widths and horizontal alignement of each column are 
     set through `_set_attr_dict` internal function.
 
     Args:
@@ -521,12 +521,12 @@ def _set_kpi_attributes(cols_list):
 
 
 def _set_if_ana_attributes(cols_list):
-    """Sets the widths and horizontal alignement of each columns 
+    """Sets the widths and horizontal alignement of each column 
     and the heights of the first row and other rows to be used 
     for formatting the analysis results to be saved for the 
     impact-factors data.
 
-    The widths and horizontal alignement of each columns are 
+    The widths and horizontal alignement of each column are 
     set through `_set_attr_dict` internal function.
 
     Args:
@@ -552,12 +552,12 @@ def _set_if_ana_attributes(cols_list):
 
 
 def _set_kw_attributes(cols_list):
-    """Sets the widths and horizontal alignement of each columns 
+    """Sets the widths and horizontal alignement of each column 
     and the heights of the first row and other rows to be used 
     for formatting the analysis results to be saved for the 
     keywords data.
 
-    The widths and horizontal alignement of each columns are 
+    The widths and horizontal alignement of each column are 
     set through `_set_attr_dict` internal function.
 
     Args:
@@ -583,12 +583,12 @@ def _set_kw_attributes(cols_list):
 
 
 def _set_geo_attributes(cols_list):
-    """Sets the widths and horizontal alignement of each columns 
+    """Sets the widths and horizontal alignement of each column 
     and the heights of the first row and other rows to be used 
     for formatting the analysis results to be saved for the 
     geographical data.
 
-    The widths and horizontal alignement of each columns are 
+    The widths and horizontal alignement of each column are 
     set through `_set_attr_dict` internal function.
 
     Args:
@@ -614,11 +614,11 @@ def _set_geo_attributes(cols_list):
 
 
 def _set_norm_inst_attributes(cols_list):
-    """Sets the widths and horizontal alignement of each columns 
+    """Sets the widths and horizontal alignement of each column 
     and the heights of the first row and other rows to be used 
     for formatting the normalized-institutions data to be saved.
 
-    The widths and horizontal alignement of each columns are 
+    The widths and horizontal alignement of each column are 
     set through `_set_attr_dict` internal function.
 
     Args:
@@ -644,11 +644,11 @@ def _set_norm_inst_attributes(cols_list):
 
 
 def _set_raw_inst_attributes(cols_list):
-    """Sets the widths and horizontal alignement of each columns 
+    """Sets the widths and horizontal alignement of each column 
     and the heights of the first row and other rows to be used 
     for formatting the raw-institutions data to be saved.
 
-    The widths and horizontal alignement of each columns are 
+    The widths and horizontal alignement of each column are 
     set through `_set_attr_dict` internal function.
 
     Args:
@@ -674,11 +674,11 @@ def _set_raw_inst_attributes(cols_list):
 
 
 def _set_distrib_inst_attributes(cols_list):
-    """Sets the widths and horizontal alignement of each columns 
+    """Sets the widths and horizontal alignement of each column 
     and the heights of the first row and other rows to be used 
     for formatting the distributed-institutions data to be saved.
 
-    The widths and horizontal alignement of each columns are 
+    The widths and horizontal alignement of each column are 
     set through `_set_attr_dict` internal function.
 
     Args:
@@ -704,7 +704,7 @@ def _set_distrib_inst_attributes(cols_list):
 
 
 def _set_inst_country_pub_attributes(cols_list):
-    """Sets the widths and horizontal alignement of each columns 
+    """Sets the widths and horizontal alignement of each column 
     and the heights of the first row and other rows to be used 
     for formatting the data of publication IDs per country and 
     per institution to be saved.
@@ -732,7 +732,7 @@ def _set_inst_country_pub_attributes(cols_list):
 
 
 def _set_pub_country_inst_attributes(cols_list):
-    """Sets the widths and horizontal alignement of each columns 
+    """Sets the widths and horizontal alignement of each column 
     and the heights of the first row and other rows to be used 
     for formatting the data of institutions per country and per 
     publication ID to be saved.
@@ -760,7 +760,7 @@ def _set_pub_country_inst_attributes(cols_list):
 
 
 def _set_country_inst_pub_attributes(cols_list):
-    """Sets the widths and horizontal alignement of each columns 
+    """Sets the widths and horizontal alignement of each column 
     and the heights of the first row and other rows to be used 
     for formatting the data of publication IDs per institutions 
     and per country to be saved.
@@ -789,7 +789,7 @@ def _set_country_inst_pub_attributes(cols_list):
 
 
 def _set_doctype_stat_attributes(cols_list):
-    """Sets the widths and horizontal alignement of each columns 
+    """Sets the widths and horizontal alignement of each column 
     and the heights of the first row and other rows to be used 
     for formatting the statistics data of doctype-analysis results 
     to be saved.

--- a/bmfuncts/merge_pub_employees.py
+++ b/bmfuncts/merge_pub_employees.py
@@ -28,6 +28,7 @@ from bmfuncts.rename_cols import build_col_conversion_dic
 from bmfuncts.useful_functs import concat_dfs
 from bmfuncts.useful_functs import keep_initials
 from bmfuncts.useful_functs import set_year_pub_id
+from bmfuncts.useful_functs import standardize_full_name_order
 from bmfuncts.useful_functs import standardize_txt
 
 
@@ -122,7 +123,7 @@ def _set_full_ref(title, first_author, journal_name, pub_year, doi):
         (str): Full reference of the publication.
     """
     full_ref  = f'{title}, '                     # add the reference's title
-    full_ref += f'{first_author}. et al., '      # add the reference's first author
+    full_ref += f'{first_author} et al., '      # add the reference's first author
     full_ref += f'{journal_name.capitalize()}, ' # add the reference's journal name
     full_ref += f'{pub_year}, '                  # add the reference's publication year
     full_ref += f'{doi}'                         # add the reference's DOI
@@ -168,6 +169,7 @@ def _add_biblio_list(in_path, out_path):
         pub_id_first_row = pub_id_df.iloc[0]
         title = str(pub_id_first_row[pub_title_alias])
         first_author = str(pub_id_first_row[pub_first_author_alias])
+        first_author = standardize_full_name_order(first_author)
         journal_name = str(pub_id_first_row[pub_journal_alias])
         pub_year = str(pub_id_first_row[pub_year_alias])
         doi = str(pub_id_first_row[pub_doi_alias])

--- a/bmfuncts/pub_globals.py
+++ b/bmfuncts/pub_globals.py
@@ -11,6 +11,7 @@ __all__ = ['ANALYSIS_IF',
            'ARCHI_ORPHAN',
            'ARCHI_RESULTS',
            'ARCHI_YEAR',
+           'AUTHORS_FULL_LIST_NAME_CORRECTION',
            'BDD_LIST',
            'BM_LOW_WORDS_LIST',
            'COL_HASH',
@@ -67,7 +68,8 @@ DF_TITLES_LIST = ["Pub_df", "Homonyms_df", "OTP_df", "IF_db_df",
                   "IF_anal_df", "Distrib_inst_df",
                   "inst_country_pub_df", "doctype_stat_df",
                   "pub_country_inst_df", "country_inst_pub_df",
-                  "raw_institutions_df"]
+                  "raw_institutions_df", "invalids_df",
+                  "missing_if_issn_df"]
 
 CONFIG_FOLDER = 'ConfigFiles'
 
@@ -80,6 +82,8 @@ TSV_SAVE_EXTENT = "dat"
 XL_INDEX_BASE = 1
 
 LISTES_CONCAT = False
+
+AUTHORS_FULL_LIST_NAME_CORRECTION = False
 
 ARCHI_BACKUP = {"root" : "Sauvegarde de secours"}
 
@@ -244,8 +248,9 @@ SHEET_SAVE_OTP = {'hash_OTP': 'Hash_ID-OTP',
 
 
 COL_NAMES_BONUS = {'nom prénom'       : "Nom, Prénom de l'auteur ",
-                   'nom prénom liste' : "Liste ordonnée des auteurs ",
+                   'nom prénom liste' : "Liste ordonnée des auteurs de l'institut",
                    'liste biblio'     : "Référence bibliographique complète",
+                   'liste auteurs'    : "Liste ordonnée de tous les auteurs",
                    'author_type'      : "Type de l'auteur",
                    'homonym'          : "Homonymes",
                    'list OTP'         : "Choix de l'OTP",

--- a/bmfuncts/rename_cols.py
+++ b/bmfuncts/rename_cols.py
@@ -40,7 +40,8 @@ def build_col_conversion_dic(institute, org_tup):
     dpt_col_list   = list(col_names_dpt.values())
     inst_col_list  = org_tup[4]
 
-    init_orphan_col_list = sum([bp.COL_NAMES['auth_inst'][:5],
+    init_orphan_col_list = sum([[pg.COL_HASH['hash_id']],
+                                bp.COL_NAMES['auth_inst'][:5],
                                 inst_col_list,
                                 [bp.COL_NAMES['authors'][2]],
                                 bp.COL_NAMES['articles'][1:11],
@@ -57,14 +58,16 @@ def build_col_conversion_dic(institute, org_tup):
                                  pg.COL_NAMES_BONUS['liste biblio']]], [])
 
     init_bm_col_list = sum([init_submit_col_list,
-                            [pg.COL_NAMES_BONUS['nom prénom liste'] + institute,
+                            [pg.COL_NAMES_BONUS['nom prénom liste'],
+                             pg.COL_NAMES_BONUS['liste auteurs'],
                              pg.COL_NAMES_BONUS['nom prénom'] + institute],
                             [pg.COL_NAMES_BONUS['list OTP'],
                              pg.COL_NAMES_BONUS['IF en cours'],
                              pg.COL_NAMES_BONUS['IF année publi']],
                             dpt_col_list], [])
 
-    final_bm_col_list = sum([["Pub_id",
+    final_bm_col_list = sum([["Hash_id",
+                              "Pub_id",
                               "Auteur_id",
                               "Adresse",
                               "Pays",
@@ -106,7 +109,8 @@ def build_col_conversion_dic(institute, org_tup):
                              list(eg.EMPLOYEES_ADD_COLS.values()),
                              [pg.COL_NAMES_BONUS['author_type'],
                               pg.COL_NAMES_BONUS['liste biblio'],
-                              pg.COL_NAMES_BONUS['nom prénom liste'] + institute,
+                              pg.COL_NAMES_BONUS['nom prénom liste'],
+                              pg.COL_NAMES_BONUS['liste auteurs'],
                               pg.COL_NAMES_BONUS['nom prénom'] + institute],
                              [pg.COL_NAMES_BONUS['list OTP'],
                               pg.COL_NAMES_BONUS['IF en cours'],
@@ -141,10 +145,12 @@ def set_homonym_col_names(institute, org_tup):
     col_rename_tup = build_col_conversion_dic(institute, org_tup)
     all_col_rename_dic = col_rename_tup[2]
 
-    homonyms_col_dic_init = {'pub_id'        : bp.COL_NAMES['pub_id'],
+    homonyms_col_dic_init = {'hash_id'       : pg.COL_HASH['hash_id'],
+                             'pub_id'        : bp.COL_NAMES['pub_id'],
                              'corpus_year'   : pg.COL_NAMES_BONUS['corpus_year'],
                              'final_year'    : bp.COL_NAMES['articles'][2],
                              'inst_author'   : bp.COL_NAMES['authors'][2],
+                             "all_authors"   : pg.COL_NAMES_BONUS['liste auteurs'],
                              'first_author'  : bp.COL_NAMES['articles'][1],
                              'title'         : bp.COL_NAMES['articles'][9],
                              'journal'       : bp.COL_NAMES['articles'][3],
@@ -191,11 +197,13 @@ def set_otp_col_names(institute, org_tup):
     col_rename_tup = build_col_conversion_dic(institute, org_tup)
     all_col_rename_dic = col_rename_tup[2]
 
-    otp_col_dic_init = {'pub_id'            : bp.COL_NAMES['pub_id'],
+    otp_col_dic_init = {'hash_id'           : pg.COL_HASH['hash_id'],
+                        'pub_id'            : bp.COL_NAMES['pub_id'],
                         'corpus_year'       : pg.COL_NAMES_BONUS['corpus_year'],
                         'final_year'        : bp.COL_NAMES['articles'][2],
                         'first_author'      : bp.COL_NAMES['articles'][1],
-                        "institute_authors" : pg.COL_NAMES_BONUS['nom prénom liste'] + institute,
+                        "institute_authors" : pg.COL_NAMES_BONUS['nom prénom liste'],
+                        "all_authors"       : pg.COL_NAMES_BONUS['liste auteurs'],
                         'title'             : bp.COL_NAMES['articles'][9],
                         'journal'           : bp.COL_NAMES['articles'][3],
                         'doc_type'          : bp.COL_NAMES['articles'][7],
@@ -241,11 +249,13 @@ def set_final_col_names(institute, org_tup):
     col_rename_tup = build_col_conversion_dic(institute, org_tup)
     all_col_rename_dic = col_rename_tup[2]
 
-    final_col_dic_init = {'pub_id'            : bp.COL_NAMES['pub_id'],
+    final_col_dic_init = {'hash_id'           : pg.COL_HASH['hash_id'],
+                          'pub_id'            : bp.COL_NAMES['pub_id'],
                           'corpus_year'       : pg.COL_NAMES_BONUS['corpus_year'],
                           'final_year'        : bp.COL_NAMES['articles'][2],
                           'first_author'      : bp.COL_NAMES['articles'][1],
-                          'institute_authors' : pg.COL_NAMES_BONUS['nom prénom liste'] + institute,
+                          'institute_authors' : pg.COL_NAMES_BONUS['nom prénom liste'],
+                          "all_authors"       : pg.COL_NAMES_BONUS['liste auteurs'],
                           'title'             : bp.COL_NAMES['articles'][9],
                           'journal'           : bp.COL_NAMES['articles'][3],
                           'doc_type'          : bp.COL_NAMES['articles'][7],
@@ -319,28 +329,30 @@ def set_col_attr(institute, org_tup, columns_list):
     col_rename_tup = build_col_conversion_dic(institute, org_tup)
     all_col_rename_dic = col_rename_tup[2]
 
-    init_col_attr   = {bp.COL_NAMES['pub_id']                             : [20, "center"],
-                       pg.COL_NAMES_BONUS['nom prénom liste'] + institute : [40, "left"],
-                       bp.COL_NAMES['authors'][1]                         : [15, "center"],
-                       eg.EMPLOYEES_USEFUL_COLS['matricule']              : [15, "center"],
-                       eg.EMPLOYEES_USEFUL_COLS['name']                   : [20, "center"],
-                       eg.EMPLOYEES_USEFUL_COLS['first_name']             : [20, "center"],
-                       bp.COL_NAMES['articles'][9]                        : [40, "left"],
-                       bp.COL_NAMES['articles'][1]                        : [20, "center"],
-                       pg.COL_NAMES_BONUS['IF en cours']                  : [15, "center"],
-                       pg.COL_NAMES_BONUS['IF année publi']               : [15, "center"],
-                       bp.COL_NAMES['articles'][6]                        : [20, "left"],
-                       bp.COL_NAMES['articles'][10]                       : [15, "center"],
-                       bp.COL_NAMES['articles'][2]                        : [15, "center"],
-                       bp.COL_NAMES['articles'][3]                        : [40, "left"],
-                       bp.COL_NAMES['articles'][7]                        : [20, "center"],
-                       pg.COL_NAMES_BONUS['corpus_year']                  : [15, "center"],
-                       eg.EMPLOYEES_USEFUL_COLS['dpt']                    : [15, "center"],
-                       eg.EMPLOYEES_USEFUL_COLS['serv']                   : [15, "center"],
-                       eg.EMPLOYEES_USEFUL_COLS['lab']                    : [15, "center"],
-                       pg.COL_NAMES_BONUS['liste biblio']                 : [55, 'left'],
-                       pg.COL_NAMES_BONUS['homonym']                      : [20, "center"],
-                       pg.COL_NAMES_BONUS['list OTP']                     : [75, "center"],
+    init_col_attr   = {pg.COL_HASH['hash_id']                 : [25, "center"],
+                       bp.COL_NAMES['pub_id']                 : [20, "center"],
+                       pg.COL_NAMES_BONUS['nom prénom liste'] : [40, "left"],
+                       pg.COL_NAMES_BONUS['liste auteurs']    : [40, "left"],
+                       bp.COL_NAMES['authors'][1]             : [15, "center"],
+                       eg.EMPLOYEES_USEFUL_COLS['matricule']  : [15, "center"],
+                       eg.EMPLOYEES_USEFUL_COLS['name']       : [20, "center"],
+                       eg.EMPLOYEES_USEFUL_COLS['first_name'] : [20, "center"],
+                       bp.COL_NAMES['articles'][9]            : [40, "left"],
+                       bp.COL_NAMES['articles'][1]            : [20, "center"],
+                       pg.COL_NAMES_BONUS['IF en cours']      : [15, "center"],
+                       pg.COL_NAMES_BONUS['IF année publi']   : [15, "center"],
+                       bp.COL_NAMES['articles'][6]            : [20, "left"],
+                       bp.COL_NAMES['articles'][10]           : [15, "center"],
+                       bp.COL_NAMES['articles'][2]            : [15, "center"],
+                       bp.COL_NAMES['articles'][3]            : [40, "left"],
+                       bp.COL_NAMES['articles'][7]            : [20, "center"],
+                       pg.COL_NAMES_BONUS['corpus_year']      : [15, "center"],
+                       eg.EMPLOYEES_USEFUL_COLS['dpt']        : [15, "center"],
+                       eg.EMPLOYEES_USEFUL_COLS['serv']       : [15, "center"],
+                       eg.EMPLOYEES_USEFUL_COLS['lab']        : [15, "center"],
+                       pg.COL_NAMES_BONUS['liste biblio']     : [55, 'left'],
+                       pg.COL_NAMES_BONUS['homonym']          : [20, "center"],
+                       pg.COL_NAMES_BONUS['list OTP']         : [75, "center"],
                       }
     for _,dpt_col_name in col_names_dpt.items():
         init_col_attr[col_names_dpt[dpt_col_name]] = [10, "center"]

--- a/bmfuncts/use_otps.py
+++ b/bmfuncts/use_otps.py
@@ -467,7 +467,7 @@ def _set_lab_otp_ws(lab, dfs_tup, lab_otp_list, wb, first, common_args_tup):
 
 def _re_save_labs_otp_file(dpt_pub_dict, dpt_lab_otps_dict,
                            dpt_otp_file_name_path, otps_history_tup):
-    """Rebuilds and saves the OTPs data for a department as a multisheet 
+    """Rebuilds and saves the OTPs data for a department as a multi-sheet 
     Openpyxl workbook with one sheet per lab.
 
     A data validation list is added to the cells 'otp_cell_alias' only when 

--- a/bmfuncts/useful_functs.py
+++ b/bmfuncts/useful_functs.py
@@ -53,7 +53,7 @@ def reorder_df(df, col_dict):
     
     A positive index gives the effective position of the column in 
     the reordered list of the columns. 
-    A negative index means that the column sis to be added at the end 
+    A negative index means that the column is to be added at the end 
     of the reordered list of the columns. The lowest negative index 
     corresponds to the first added column among the columns to be added 
     at the end.
@@ -118,7 +118,7 @@ def name_capwords(text):
 def standardize_full_name_order(author):
     """Sets the first-name initials before the last name in a full name.
 
-    It append "." after each initial and takes care of keeping '-'
+    It appends "." after each initial and takes care of keeping '-'
     between the parts of composed first names.
 
     Args:

--- a/bmgui/consolidate_corpus_page.py
+++ b/bmgui/consolidate_corpus_page.py
@@ -587,7 +587,7 @@ def _launch_pub_list_conso_try(institute, org_tup,
             print(end_message)
             progress_callback(70)
             if pg.LISTES_CONCAT:
-                end_message = concatenate_pub_lists(institute, org_tup, bibliometer_path, years_list)
+                end_message = concatenate_pub_lists(bibliometer_path, years_list)
                 print('\n',end_message)
             progress_callback(100)
             info_title = "- Information -"

--- a/release_note.md
+++ b/release_note.md
@@ -19,6 +19,7 @@
   - Improvement 10: Addition of "doctypes_analysis" module to provide statistics of publications by journals, conference proceedings or books.
   - Improvement 11: Substitution of "impact_factors_analysis" module by "build_kpi" one for the sake of clarity.
   - Improvement 12: Addition of author job type and matriculate to the results provided by "author_analysis" module through the use of publications list with one row per author after solving homonymies.
+  - Improvement 13: Integration to the saved results the Hash-ID and the full list of authors for each publication.
 * **Bug Fixes**:
   - None.
 * **Known Issues**:


### PR DESCRIPTION
The authors full list is built from the parsing data and added to the data at the step of the merge between authors and employees. At the same time a column with the publication Hash-id is added as first column in all data. This required  the refactoring of the "format_files" and "rename_cols"  modules and to addapt the other modules of the bmfuncts package.
